### PR TITLE
Add build and private release in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: GitHub CI
+
+# Run only on main branch (avoids duplicated actions on PRs)
+on:
+  pull_request:
+  push:
+    tags:
+      - "*"
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install build requirements
+        run: |
+          pip install -U pip
+          pip install build
+
+      - name: Build
+        run: python -m build
+
+      - name: Install
+        run: pip install dist/*.whl
+
+      - name: Test import
+        run: |
+          mkdir tmp
+          cd tmp
+          python -c "from ansys.api.edb import __version__; print(__version__)"
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: ansys-api-edb-package
+          path: dist/
+          retention-days: 7
+
+  release:
+    name: release package on private PyPi
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - uses: actions/download-artifact@v2
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Upload to Private PyPI
+        run: |
+          pip install twine
+          twine upload --skip-existing ./**/*.whl
+          twine upload --skip-existing ./**/*.tar.gz
+        env:
+          TWINE_USERNAME: PAT
+          TWINE_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }} 
+          TWINE_REPOSITORY_URL: https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload
+
+      # uncomment the following section to permit upload to public PyPI
+
+      # - name: Upload to Public PyPi
+      #   run: |
+      #     pip install twine
+      #     twine upload --skip-existing ./**/*.whl
+      #     twine upload --skip-existing ./**/*.tar.gz
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }} 
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            ./**/*.whl
+            ./**/*.tar.gz


### PR DESCRIPTION
This should be usefull to let other repos install ansys-api-edb even if it is private and on anoher organization.