### PR TITLE
Removing depreciated ArcResolution setting from RaptorX solution setups

### DIFF
--- a/ansys/api/edb/v1/raptor_x_simulation_settings.proto
+++ b/ansys/api/edb/v1/raptor_x_simulation_settings.proto
@@ -60,12 +60,6 @@ service RaptorXAdvancedSettingsService {
   rpc GetEliminateSlitPerHoles(EDBObjMessage) returns (google.protobuf.DoubleValue) {}
   rpc SetEliminateSlitPerHoles(DoublePropertyMessage) returns (google.protobuf.Empty) {}
 
-  rpc GetUseArcResolution(EDBObjMessage) returns (google.protobuf.BoolValue) {}
-  rpc SetUseArcResolution(BoolPropertyMessage) returns (google.protobuf.Empty) {}
-
-  rpc GetArcResolution(EDBObjMessage) returns (google.protobuf.StringValue) {}
-  rpc SetArcResolution(StringPropertyMessage) returns (google.protobuf.Empty) {}
-
   rpc GetUseAutoRemovalSliverPoly(EDBObjMessage) returns (google.protobuf.BoolValue) {}
   rpc SetUseAutoRemovalSliverPoly(BoolPropertyMessage) returns (google.protobuf.Empty) {}
 


### PR DESCRIPTION
Removing depreciated ArcResolution setting from RaptorX solution setups