### PR TITLE
Add: Add streaming APIs for EDBObjCollectionMessage

### DIFF
--- a/ansys/api/edb/v1/bundle_term.proto
+++ b/ansys/api/edb/v1/bundle_term.proto
@@ -11,4 +11,5 @@ service BundleTerminalService {
   rpc Ungroup (EDBObjMessage) returns (google.protobuf.Empty) {}
 
   rpc GetTerminals (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamTerminals (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 }

--- a/ansys/api/edb/v1/cell.proto
+++ b/ansys/api/edb/v1/cell.proto
@@ -99,6 +99,7 @@ service CellService {
 
   // Get simulation setups
   rpc GetSimulationSetups (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamSimulationSetups (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Generate auto HFSS regions
   rpc GenerateAutoHFSSRegions (EDBObjMessage) returns (google.protobuf.Empty) {}

--- a/ansys/api/edb/v1/cell_instance.proto
+++ b/ansys/api/edb/v1/cell_instance.proto
@@ -26,6 +26,7 @@ service CellInstanceService {
 
   // Terminal Instances
   rpc GetTermInsts(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamTermInsts(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Get if component is 3dplaced
   rpc GetIs3DPlacement(EDBObjMessage) returns (google.protobuf.BoolValue) {}

--- a/ansys/api/edb/v1/component_def.proto
+++ b/ansys/api/edb/v1/component_def.proto
@@ -30,14 +30,16 @@ service ComponentDefService {
 
   // Get the component models owned by this component def
   rpc GetComponentModels(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamComponentModels(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Get the component pins owned by this component def.
   rpc GetComponentPins(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamComponentPins(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Add component model to this component def
   rpc AddComponentModel(EDBObjPairMessage) returns (google.protobuf.Empty) {}
 
-  // Remove component model to this component def
+  // Remove component from this component def
   rpc RemoveComponentModel(EDBObjPairMessage) returns (google.protobuf.Empty) {}
 }
 

--- a/ansys/api/edb/v1/database.proto
+++ b/ansys/api/edb/v1/database.proto
@@ -35,6 +35,7 @@ service DatabaseService {
 
   // Gets the top circuits in a database
   rpc GetTopCircuits (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamTopCircuits (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Gets the id of a database
   rpc GetId (EDBObjMessage) returns (google.protobuf.Int64Value) {} 
@@ -69,11 +70,14 @@ service DatabaseService {
 
   // Get defs
   rpc GetDefinitionObjs (GetDefinitionObjsMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamDefinitionObjs (GetDefinitionObjsMessage) returns (stream EDBObjCollectionMessage) {}
   
   // get cells
   rpc TopCircuitCells (EDBObjMessage) returns (EDBObjCollectionMessage) {}
   rpc GetCircuits (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamCircuits (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
   rpc GetFootprints (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamFootprints (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
   
 }
 

--- a/ansys/api/edb/v1/edge_term.proto
+++ b/ansys/api/edb/v1/edge_term.proto
@@ -28,6 +28,7 @@ service EdgeTerminalService {
   rpc Create (EdgeTermCreationMessage) returns (EDBObjMessage) {}
 
   rpc GetEdges (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamEdges (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   rpc SetEdges (EdgeTermSetEdgesMessage) returns (google.protobuf.Empty) {}
 }

--- a/ansys/api/edb/v1/group.proto
+++ b/ansys/api/edb/v1/group.proto
@@ -28,6 +28,7 @@ service GroupService {
 
   // Get iterable for group members
   rpc GetMembers(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamMembers(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Get the type of the group
   rpc GetGroupType(EDBObjMessage) returns (GroupTypeMessage) {}

--- a/ansys/api/edb/v1/layer_collection.proto
+++ b/ansys/api/edb/v1/layer_collection.proto
@@ -53,6 +53,7 @@ service LayerCollectionService {
 
   // Get a list of layers in the LayerCollection filtered by the given layer filter
   rpc GetLayers (GetLayersMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamLayers (GetLayersMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Get the layer's product property corresponding to the given product and attribute ids
   rpc GetProductProperty (GetProductPropertyMessage) returns (google.protobuf.StringValue) {}

--- a/ansys/api/edb/v1/layout.proto
+++ b/ansys/api/edb/v1/layout.proto
@@ -25,6 +25,7 @@ service LayoutService {
 
   // Gets the layout objects that belong to the layout
   rpc GetItems (LayoutGetItemsMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamItems (LayoutGetItemsMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Get expanded extent from nets
   rpc GetExpandedExtentFromNets (LayoutExpandedExtentMessage) returns (PolygonDataMessage) {}
@@ -37,6 +38,7 @@ service LayoutService {
 
   // Gets list of zone primitives
   rpc GetZonePrimitives (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamZonePrimitives (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Set fixed zone primitives
   rpc SetFixedZonePrimitives (PointerPropertyMessage) returns (google.protobuf.Empty) {}
@@ -46,6 +48,7 @@ service LayoutService {
 
   // Get board bend definitions
   rpc GetBoardBendDefs (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamBoardBendDefs (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Synchronize bend manager
   rpc SynchronizeBendManager (EDBObjMessage) returns (google.protobuf.Empty) {}

--- a/ansys/api/edb/v1/layout_instance.proto
+++ b/ansys/api/edb/v1/layout_instance.proto
@@ -17,6 +17,7 @@ service LayoutInstanceService {
   rpc GetLayoutObjInstanceInContext(GetLayoutObjInstanceInContextMessage) returns (EDBObjMessage) {}
 
   rpc GetConnectedObjects(GetConnectedObjectsMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamConnectedObjects(GetConnectedObjectsMessage) returns (stream EDBObjCollectionMessage) {}
 }
 
 message LayoutObjInstancesQueryMessage {

--- a/ansys/api/edb/v1/net.proto
+++ b/ansys/api/edb/v1/net.proto
@@ -25,6 +25,7 @@ service NetService {
 
   // layout objects getter
   rpc GetLayoutObjects (NetGetLayoutObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamLayoutObjects (NetGetLayoutObjMessage) returns (stream EDBObjCollectionMessage) {}
 }
 
 message NetGetLayoutObjMessage {

--- a/ansys/api/edb/v1/netclass.proto
+++ b/ansys/api/edb/v1/netclass.proto
@@ -22,6 +22,7 @@ service NetClassService {
   rpc IsPowerGround(EDBObjMessage) returns (google.protobuf.BoolValue) {}
   
   rpc GetNets(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamNets(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
   
   rpc AddNet(NetClassEditMessage) returns (google.protobuf.Empty) {}
 

--- a/ansys/api/edb/v1/padstack_instance.proto
+++ b/ansys/api/edb/v1/padstack_instance.proto
@@ -83,7 +83,8 @@ service PadstackInstanceService {
   rpc IsInPinGroup(PadstackInstIsInPinGroupMessage) returns (google.protobuf.BoolValue) {}
   
   // Get pin groups of PadstackInst
-  rpc GetPinGroups(EDBObjMessage) returns (EDBObjCollectionMessage ) {}
+  rpc GetPinGroups(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamPinGroups(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
 }
 

--- a/ansys/api/edb/v1/pin_group.proto
+++ b/ansys/api/edb/v1/pin_group.proto
@@ -20,6 +20,7 @@ service PinGroupService {
   rpc RemovePins (PinGroupPinsModifyMessage) returns (google.protobuf.Empty) {}
 
   rpc GetPins (EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamPins (EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 }
 
 message PinGroupCreationMessage {

--- a/ansys/api/edb/v1/primitive.proto
+++ b/ansys/api/edb/v1/primitive.proto
@@ -54,6 +54,7 @@ service PrimitiveService {
 
   // Gets an iterator of the voids in the Primitive
   rpc Voids(EDBObjMessage) returns (EDBObjCollectionMessage) {}
+  rpc StreamVoids(EDBObjMessage) returns (stream EDBObjCollectionMessage) {}
 
   // Get Owner
   rpc GetOwner(EDBObjMessage) returns (EDBObjMessage) {}


### PR DESCRIPTION
Changes:
- for all APIs returning EDBObjCollectionMessage, create a duplicate API streaming down the same message.

Note:
- EDBObjCollectionMessage can hit the message size limit (4MB) around 700,000 items