### PR TITLE
build: bump protobuf upper bound to <7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper>=0.4.0"]
+requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper>=0.6.0"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         long_description_content_type='text/markdown',
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
-        python_requires=">=3.7",
+        python_requires=">=3.10",
         install_requires=["grpcio>=1.44", "protobuf>=3.19.3,<7"],
         packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
         python_requires=">=3.7",
-        install_requires=["grpcio>=1.44", "protobuf>=3.19.3,<5"],
+        install_requires=["grpcio>=1.44", "protobuf>=3.19.3,<7"],
         packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
         package_data={
             "": ["*.proto", "*.pyi", "py.typed", "VERSION"],


### PR DESCRIPTION
As title says, should also handle CVE-2026-0994 which shouldn't be impacting us AFAIK.